### PR TITLE
Fixes inputs by changing to datetime-local

### DIFF
--- a/js/templates.js
+++ b/js/templates.js
@@ -1,7 +1,7 @@
 var templates = {
    input: '<div class="form-group">' +
             '<label for="event-{{id}}" class="control-label circle">{{eventNumber}}</label>' +
-            '<input type="datetime" class="form-control" id="event-{{id}}" name="e" value="{{value}}" placeholder="yyyy-mm-ddThh:mm:ss±hh:mm">' +
+            '<input type="datetime-local" class="form-control" id="event-{{id}}" name="e" value="{{value}}" placeholder="yyyy-mm-ddThh:mm:ss±hh:mm">' +
             '<button type="button" class="close delete-event" aria-hidden="true" title="Delete this event">&times;</button>' +
           '</div>',
 


### PR DESCRIPTION
Support for an input of type "datetime" has [apparently been dropped from modern browsers](https://stackoverflow.com/questions/21263515/why-is-html5-input-type-datetime-removed-from-browsers-already-supporting-it), in favor of ["datetime-local"](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local).

Because of this, the app currently displays empty text inputs. Changing them to "datetime-local" fixes the issue.